### PR TITLE
Install pyjolokia via pip

### DIFF
--- a/manifests/plugin/jolokia.pp
+++ b/manifests/plugin/jolokia.pp
@@ -35,7 +35,11 @@ class collectd::plugin::jolokia (
   }
 
   package { 'pyjolokia':
-    ensure => $collectd::plugin::jolokia::ensure,
-    notify => Service['collectd'];
+    ensure   => $collectd::plugin::jolokia::ensure,
+    notify   => Service['collectd'],
+    provider => 'pip',
+    require  => Package['python-pip'],
   }
+
+  ensure_packages('python-pip')
 }


### PR DESCRIPTION
package pyjolokia is not found via native package managers ... so install it via pip 
